### PR TITLE
[AND-5242] AloomaHelper allows multiple alooma instances

### DIFF
--- a/src/main/java/com/github/aloomaio/androidsdk/aloomametrics/AloomaAPI.java
+++ b/src/main/java/com/github/aloomaio/androidsdk/aloomametrics/AloomaAPI.java
@@ -127,6 +127,7 @@ public class AloomaAPI {
     AloomaAPI(Context context, Future<SharedPreferences> referrerPreferences, String token,
               String aloomaHost, boolean forceSSL) {
         mToken = token;
+        mRegisteredHost = aloomaHost;
         mContext = context;
         mEventTimings = new HashMap<String, Long>();
         mPeople = new PeopleImpl();
@@ -371,7 +372,7 @@ public class AloomaAPI {
         }
     }
 
-    private static boolean validateToken(String token) {
+    public static boolean validateToken(String token) {
         try {
             String tokenData = token.substring(token.indexOf('.') + 1, token.lastIndexOf('.'));
             String decoded = new String(Base64.decode(tokenData, 0));
@@ -495,6 +496,16 @@ public class AloomaAPI {
      */
     public String getDistinctId() {
         return mPersistentIdentity.getEventsDistinctId();
+     }
+
+    /**
+     * Returns the associated host with this instance.
+     * Host information is read only and specified at instance creation.
+     *
+     * @return Host the instance sends events to.
+     */
+    public String getRegisteredHost() {
+        return mRegisteredHost;
      }
 
     /**
@@ -1854,7 +1865,7 @@ public class AloomaAPI {
     }
 
     private static final String LOGTAG = "AloomaAPI.AloomaAPI";
-    private static final String APP_LINKS_LOGTAG = "AloomaAPI - App Links (OPTIONAL)";
+    private static final String APP_LINKS_LOGTAG = "AloomaAPI - App Links";
     private static final String ENGAGE_DATE_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ss";
 
     private final Context mContext;
@@ -1862,6 +1873,7 @@ public class AloomaAPI {
     private final AConfig mConfig;
 
     private final String mToken;
+    private final String mRegisteredHost;
     private final PeopleImpl mPeople;
     private final UpdatesFromMixpanel mUpdatesFromMixpanel;
     private final PersistentIdentity mPersistentIdentity;


### PR DESCRIPTION
### Note to reviewers
At the end, it was not necessary to code a custom constructor for `AloomaApi`. 
Method `getInstance()` internally creates a new alooma instance per token and caches it in a map structure, so just few changes needed on alooma sdk just to improve testability of this feature.
Please check related PR https://github.com/roverdotcom/android/pull/4813

### Background

The way we are currently using the Alooma library is through a Singleton “sharedInstance” exposed by the library. This singleton is a convenience so that you can easily interact directly with the Alooma library from anywhere in the application. However, in both applications, we have a single class that wraps our interactions: AloomaHelper on Android and GoogleTagManagerService on iOS.

In order to instantiate multiple clients (one to send events to Alooma and one to send events to our internal Eventstream endpoint), we’ll need to move off of this singleton and use the regular constructor to create an instance that we store in the parent class.

For this stage, we’ll swap our usage of the “sharedInstance” with constructing an instance of our own.

The non-singleton constructor:  

### Definition of Done

Include need for documentation, unit testing, cross-team communication, etc

We no longer use the "sharedInstance" singleton to create and use the Alooma client

