### PR TITLE
[AND-5423] - Allow custom headers to be passed when creating AloomaApi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ android {
 // have to change the bit in uploadArchives that marks all dependencies as optional.
 dependencies {
     implementation 'com.google.android.gms:play-services-gcm:9.4.0'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'androidx.test:core:1.0.0'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
 }
 
 android.libraryVariants.all { variant ->

--- a/src/androidTest/java/com/github/aloomaio/androidsdk/aloomametrics/DecideCheckerTest.java
+++ b/src/androidTest/java/com/github/aloomaio/androidsdk/aloomametrics/DecideCheckerTest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.test.AndroidTestCase;
 
+import com.github.aloomaio.androidsdk.util.HttpService;
 import com.github.aloomaio.androidsdk.viewcrawler.UpdatesFromMixpanel;
 
 import org.json.JSONArray;
@@ -322,7 +323,7 @@ public class DecideCheckerTest extends AndroidTestCase {
         }
     }
 
-    private static class MockPoster extends ServerMessage {
+    private static class MockPoster extends HttpService {
         @Override
         public byte[] getUrls(Context context, String[] urls) {
             requestedUrls = urls;

--- a/src/androidTest/java/com/github/aloomaio/androidsdk/aloomametrics/DecideFunctionalTest.java
+++ b/src/androidTest/java/com/github/aloomaio/androidsdk/aloomametrics/DecideFunctionalTest.java
@@ -6,6 +6,7 @@ import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.test.AndroidTestCase;
 
+import com.github.aloomaio.androidsdk.util.HttpService;
 import com.github.aloomaio.androidsdk.viewcrawler.UpdatesFromMixpanel;
 
 import org.apache.http.NameValuePair;
@@ -55,7 +56,7 @@ public class DecideFunctionalTest extends AndroidTestCase {
         };
 
         mExpectations = new Expectations();
-        mMockPoster = new ServerMessage() {
+        mMockPoster = new HttpService() {
             @Override
             public byte[] performRequest(String endpointUrl, List<NameValuePair> nameValuePairs) {
                 return mExpectations.setExpectationsRequest(endpointUrl, nameValuePairs);
@@ -71,7 +72,7 @@ public class DecideFunctionalTest extends AndroidTestCase {
 
         mMockMessages = new AnalyticsMessages(getContext()) {
             @Override
-            protected ServerMessage getPoster() {
+            protected HttpService getPoster() {
                 return mMockPoster;
             }
 
@@ -330,6 +331,6 @@ public class DecideFunctionalTest extends AndroidTestCase {
     private AConfig mMockConfig;
     private Future<SharedPreferences> mMockPreferences;
     private Expectations mExpectations;
-    private ServerMessage mMockPoster;
+    private HttpService mMockPoster;
     private AnalyticsMessages mMockMessages;
 }

--- a/src/androidTest/java/com/github/aloomaio/androidsdk/aloomametrics/HttpTest.java
+++ b/src/androidTest/java/com/github/aloomaio/androidsdk/aloomametrics/HttpTest.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.test.AndroidTestCase;
 
 import com.github.aloomaio.androidsdk.util.Base64Coder;
+import com.github.aloomaio.androidsdk.util.HttpService;
 
 import org.apache.http.NameValuePair;
 import org.json.JSONArray;
@@ -32,7 +33,7 @@ public class HttpTest extends AndroidTestCase {
         mCleanupCalls = new ArrayList<String>();
         mDecideResults = new ArrayList<Object>();
 
-        final ServerMessage mockPoster = new ServerMessage() {
+        final HttpService mockPoster = new HttpService() {
             @Override
             public byte[] performRequest(String endpointUrl, List<NameValuePair> nameValuePairs) throws IOException {
                 try {
@@ -122,7 +123,7 @@ public class HttpTest extends AndroidTestCase {
             }
 
             @Override
-            protected ServerMessage getPoster() {
+            protected HttpService getPoster() {
                 return mockPoster;
             }
 

--- a/src/androidTest/java/com/github/aloomaio/androidsdk/aloomametrics/MixpanelBasicTest.java
+++ b/src/androidTest/java/com/github/aloomaio/androidsdk/aloomametrics/MixpanelBasicTest.java
@@ -14,6 +14,7 @@ import android.test.mock.MockPackageManager;
 
 import com.github.aloomaio.androidsdk.test.BuildConfig;
 import com.github.aloomaio.androidsdk.util.Base64Coder;
+import com.github.aloomaio.androidsdk.util.HttpService;
 
 import org.apache.http.NameValuePair;
 import org.json.JSONArray;
@@ -289,7 +290,7 @@ public class MixpanelBasicTest extends AndroidTestCase {
         mockAdapter.cleanupEvents(Long.MAX_VALUE, ADbAdapter.Table.EVENTS);
         mockAdapter.cleanupEvents(Long.MAX_VALUE, ADbAdapter.Table.PEOPLE);
 
-        final ServerMessage mockPoster = new ServerMessage() {
+        final HttpService mockPoster = new HttpService() {
             @Override
             public byte[] performRequest(String endpointUrl, List<NameValuePair> nameValuePairs) {
                 final boolean isIdentified = isIdentifiedRef.get();
@@ -359,7 +360,7 @@ public class MixpanelBasicTest extends AndroidTestCase {
             }
 
             @Override
-            protected ServerMessage getPoster() {
+            protected HttpService getPoster() {
                 return mockPoster;
             }
         };
@@ -793,7 +794,7 @@ public class MixpanelBasicTest extends AndroidTestCase {
     }
 
     public void testAlias() {
-        final ServerMessage mockPoster = new ServerMessage() {
+        final HttpService mockPoster = new HttpService() {
             @Override
             public byte[] performRequest(String endpointUrl, List<NameValuePair> nameValuePairs) {
                 try {
@@ -815,7 +816,7 @@ public class MixpanelBasicTest extends AndroidTestCase {
 
         final AnalyticsMessages listener = new AnalyticsMessages(getContext()) {
             @Override
-            protected ServerMessage getPoster() {
+            protected HttpService getPoster() {
                 return mockPoster;
             }
         };

--- a/src/main/java/com/github/aloomaio/androidsdk/aloomametrics/DecideChecker.java
+++ b/src/main/java/com/github/aloomaio/androidsdk/aloomametrics/DecideChecker.java
@@ -10,6 +10,8 @@ import android.util.Log;
 import android.view.Display;
 import android.view.WindowManager;
 
+import com.github.aloomaio.androidsdk.util.HttpService;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -45,7 +47,7 @@ import java.util.List;
         mChecks.add(check);
     }
 
-    public void runDecideChecks(final ServerMessage poster) {
+    public void runDecideChecks(final HttpService poster) {
         final Iterator<DecideMessages> itr = mChecks.iterator();
         while (itr.hasNext()) {
             final DecideMessages updates = itr.next();
@@ -67,7 +69,7 @@ import java.util.List;
         }
     }
 
-    private Result runDecideCheck(final String token, final String distinctId, final ServerMessage poster)
+    private Result runDecideCheck(final String token, final String distinctId, final HttpService poster)
         throws UnintelligibleMessageException {
         final String responseString = getDecideResponseFromServer(token, distinctId, poster);
         if (AConfig.DEBUG) {
@@ -167,7 +169,7 @@ import java.util.List;
         return ret;
     }
 
-    private String getDecideResponseFromServer(String unescapedToken, String unescapedDistinctId, ServerMessage poster) {
+    private String getDecideResponseFromServer(String unescapedToken, String unescapedDistinctId, HttpService poster) {
         final String escapedToken;
         final String escapedId;
         try {
@@ -214,7 +216,7 @@ import java.util.List;
         }
     }
 
-    private static Bitmap getNotificationImage(InAppNotification notification, Context context, ServerMessage poster) {
+    private static Bitmap getNotificationImage(InAppNotification notification, Context context, HttpService poster) {
         Bitmap ret = null;
         String[] urls = { notification.getImage2xUrl() };
 

--- a/src/main/java/com/github/aloomaio/androidsdk/util/HttpService.java
+++ b/src/main/java/com/github/aloomaio/androidsdk/util/HttpService.java
@@ -1,9 +1,11 @@
-package com.github.aloomaio.androidsdk.aloomametrics;
+package com.github.aloomaio.androidsdk.util;
 
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.util.Log;
+
+import com.github.aloomaio.androidsdk.aloomametrics.AConfig;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -18,8 +20,9 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 
-/* package */ class ServerMessage {
+public class HttpService implements RemoteService {
 
     public boolean isOnline(Context context) {
         boolean isOnline;
@@ -48,7 +51,7 @@ import java.util.List;
         byte[] response = null;
         for (String url : urls) {
             try {
-                response = performRequest(url, null);
+                response = performRequest(url, null, null);
                 break;
             } catch (final MalformedURLException e) {
                 Log.e(LOGTAG, "Cannot interpret " + url + " as a URL.", e);
@@ -65,7 +68,11 @@ import java.util.List;
         return response;
     }
 
-    public byte[] performRequest(String endpointUrl, List<NameValuePair> params) throws IOException {
+    public byte[] performRequest(
+            String endpointUrl,
+            List<NameValuePair> params,
+            Map<String, String> headers
+    ) throws IOException {
         if (AConfig.DEBUG) {
             Log.v(LOGTAG, "Attempting request to " + endpointUrl);
         }
@@ -88,7 +95,14 @@ import java.util.List;
                 connection = (HttpURLConnection) url.openConnection();
                 connection.setConnectTimeout(2000);
                 connection.setReadTimeout(10000);
-                if (null != params) {
+
+                if (headers != null){
+                    for (Map.Entry<String, String> header: headers.entrySet()){
+                        connection.setRequestProperty(header.getKey(), header.getValue());
+                    }
+                }
+
+                if (params != null) {
                     connection.setDoOutput(true);
                     final UrlEncodedFormEntity form = new UrlEncodedFormEntity(params, "UTF-8");
                     connection.setRequestMethod("POST");

--- a/src/main/java/com/github/aloomaio/androidsdk/util/RemoteService.java
+++ b/src/main/java/com/github/aloomaio/androidsdk/util/RemoteService.java
@@ -1,0 +1,18 @@
+package com.github.aloomaio.androidsdk.util;
+
+import android.content.Context;
+
+
+import org.apache.http.NameValuePair;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+
+public interface RemoteService {
+    boolean isOnline(Context context);
+
+    byte[] performRequest(String endpointUrl, List<NameValuePair> params, Map<String, String> headers)
+            throws IOException;
+}


### PR DESCRIPTION
### Background
As part of the Alooma Exodus project Rover has created a new API endpoint to send eventstream events to. This endpoint uses an API key for Authentication and verifies the token exists as a header on every request. This pattern is different than the current pattern the SDK uses. To support this we are allowing `AloomaApi` objects to be created with a set of custom headers sent with every request.

### DoD
- Alooma SDK can be configured to send custom headers